### PR TITLE
Extend waiting time to 10min

### DIFF
--- a/impf_termin_tester/runner.py
+++ b/impf_termin_tester/runner.py
@@ -10,7 +10,7 @@ class Runner:
         self.notifiers = notifiers
 
         self.wait_time = 5
-        self.interval_time = 5 * 60
+        self.interval_time = 10 * 60
 
     def start(self):
         self._initialize()


### PR DESCRIPTION
Impftermin website is only updating available appointments after 10min waiting time for a tracked IP.